### PR TITLE
Adding static library generation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,8 @@ if(CMAKE_COMPILER_IS_GNUCXX AND NOT WIN32)
 endif()
 
 
+OPTION(ENABLE_STATIC_LIBS "Enable building of static libraries" OFF)
+message(STATUS "Building Static Libraries: ${ENABLE_STATIC_LIBS}")
 
 ########################################################################
 # Find boost

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -36,6 +36,27 @@ target_link_libraries(fec
 )
 set_target_properties(fec PROPERTIES DEFINE_SYMBOL "fec_EXPORTS")
 
+#######################################################
+# STATIC LIB BUILD
+#######################################################
+if(ENABLE_STATIC_LIBS)
+
+    add_library(fec_static STATIC
+        cc_decoder.cc
+        generic_decoder.cc
+        generic_encoder.cc
+        cc_encoder.cc
+    )
+
+    set_target_properties(fec_static PROPERTIES OUTPUT_NAME fec)
+    install(TARGETS fec_static
+        LIBRARY DESTINATION lib${LIB_SUFFIX} # .so/.dylib file
+        ARCHIVE DESTINATION lib${LIB_SUFFIX} # .lib file
+        RUNTIME DESTINATION bin              # .dll file
+    )
+
+endif()
+
 
 IF(${CAN_HAS_GNURADIO} STREQUAL 'YESS!')
     include(GrPlatform) #define LIB_SUFFIX

--- a/volk_fecapi/lib/CMakeLists.txt
+++ b/volk_fecapi/lib/CMakeLists.txt
@@ -326,6 +326,21 @@ install(TARGETS volk_fecapi
     RUNTIME DESTINATION bin              COMPONENT "volk_fecapi_runtime" # .dll file
 )
 
+#######################################################
+# STATIC LIB BUILD
+#######################################################
+if(ENABLE_STATIC_LIBS)
+
+    add_library(volk_fecapi_static STATIC ${volk_fecapi_sources})
+    set_target_properties(volk_fecapi_static PROPERTIES DEFINE_SYMBOL "volk_fecapi_EXPORTS")
+    set_target_properties(volk_fecapi_static PROPERTIES OUTPUT_NAME volk_fecapi)
+    install(TARGETS volk_fecapi_static
+        LIBRARY DESTINATION lib${LIB_SUFFIX} COMPONENT "volk_fecapi_runtime" # .so file
+        ARCHIVE DESTINATION lib${LIB_SUFFIX} COMPONENT "volk_fecapi_devel"   # .lib file
+        RUNTIME DESTINATION bin              COMPONENT "volk_fecapi_runtime" # .dll file
+    )
+endif()
+
 ########################################################################
 # Build the QA test application
 ########################################################################

--- a/volk_fecapi/tmpl/volk_fecapi.tmpl.c
+++ b/volk_fecapi/tmpl/volk_fecapi.tmpl.c
@@ -32,7 +32,7 @@
 static size_t __alignment = 0;
 static intptr_t __alignment_mask = 0;
 
-struct volk_fecapi_machine *get_machine(void) {
+struct volk_fecapi_machine *volk_fecapi_get_machine(void) {
     extern struct volk_fecapi_machine *volk_fecapi_machines[];
     extern unsigned int n_volk_fecapi_machines;
     static struct volk_fecapi_machine *machine = NULL;
@@ -58,7 +58,7 @@ struct volk_fecapi_machine *get_machine(void) {
 
 size_t volk_fecapi_get_alignment(void)
 {
-    get_machine(); //ensures alignment is set
+    volk_fecapi_get_machine(); //ensures alignment is set
     return __alignment;
 }
 
@@ -102,15 +102,15 @@ static inline void __$(kern.name)_d($kern.arglist_full)
 
 static inline void __init_$(kern.name)(void)
 {
-    const char *name = get_machine()->$(kern.name)_name;
-    const char **impl_names = get_machine()->$(kern.name)_impl_names;
-    const int *impl_deps = get_machine()->$(kern.name)_impl_deps;
-    const bool *alignment = get_machine()->$(kern.name)_impl_alignment;
-    const size_t n_impls = get_machine()->$(kern.name)_n_impls;
+    const char *name = volk_fecapi_get_machine()->$(kern.name)_name;
+    const char **impl_names = volk_fecapi_get_machine()->$(kern.name)_impl_names;
+    const int *impl_deps = volk_fecapi_get_machine()->$(kern.name)_impl_deps;
+    const bool *alignment = volk_fecapi_get_machine()->$(kern.name)_impl_alignment;
+    const size_t n_impls = volk_fecapi_get_machine()->$(kern.name)_n_impls;
     const size_t index_a = volk_fecapi_rank_archs(name, impl_names, impl_deps, alignment, n_impls, true/*aligned*/);
     const size_t index_u = volk_fecapi_rank_archs(name, impl_names, impl_deps, alignment, n_impls, false/*unaligned*/);
-    $(kern.name)_a = get_machine()->$(kern.name)_impls[index_a];
-    $(kern.name)_u = get_machine()->$(kern.name)_impls[index_u];
+    $(kern.name)_a = volk_fecapi_get_machine()->$(kern.name)_impls[index_a];
+    $(kern.name)_u = volk_fecapi_get_machine()->$(kern.name)_impls[index_u];
 
     assert($(kern.name)_a);
     assert($(kern.name)_u);
@@ -143,20 +143,20 @@ $kern.pname $(kern.name)   = &__$(kern.name);
 void $(kern.name)_manual($kern.arglist_full, const char* impl_name)
 {
     const int index = volk_fecapi_get_index(
-        get_machine()->$(kern.name)_impl_names,
-        get_machine()->$(kern.name)_n_impls,
+        volk_fecapi_get_machine()->$(kern.name)_impl_names,
+        volk_fecapi_get_machine()->$(kern.name)_n_impls,
         impl_name
     );
-    get_machine()->$(kern.name)_impls[index](
+    volk_fecapi_get_machine()->$(kern.name)_impls[index](
         $kern.arglist_names
     );
 }
 
 volk_fecapi_func_desc_t $(kern.name)_get_func_desc(void) {
-    const char **impl_names = get_machine()->$(kern.name)_impl_names;
-    const int *impl_deps = get_machine()->$(kern.name)_impl_deps;
-    const bool *alignment = get_machine()->$(kern.name)_impl_alignment;
-    const size_t n_impls = get_machine()->$(kern.name)_n_impls;
+    const char **impl_names = volk_fecapi_get_machine()->$(kern.name)_impl_names;
+    const int *impl_deps = volk_fecapi_get_machine()->$(kern.name)_impl_deps;
+    const bool *alignment = volk_fecapi_get_machine()->$(kern.name)_impl_alignment;
+    const size_t n_impls = volk_fecapi_get_machine()->$(kern.name)_n_impls;
     volk_fecapi_func_desc_t desc = {
         impl_names,
         impl_deps,


### PR DESCRIPTION
Adding static library generation.

Changing get_machine to volk_fecapi_get_machine to avoid conflicting with the libvolk get_machine function when linking statically.
